### PR TITLE
Create skeleton for client side plus unit tests

### DIFF
--- a/client/dummyData.js
+++ b/client/dummyData.js
@@ -1,0 +1,112 @@
+export default [
+  {
+    "id":199,
+    "url":"/listings/199",
+    "title":"nostrum laboriosam in rerum officiis",
+    "type":"Shared Room",
+    "numBeds":2,
+    "price":810,
+    "numRatings":965,
+    "avgStars":0.5,
+    "thumbnailImage":"https://picsum.photos/316/210?image=199"
+  },
+  {
+    "id":180,
+    "url":"/listings/180",
+    "title":"sint itaque voluptatem eligendi",
+    "type":"Entire Place",
+    "numBeds":1,
+    "price":609,
+    "numRatings":697,
+    "avgStars":1,
+    "thumbnailImage":"https://picsum.photos/316/210?image=180"
+  },
+  {
+    "id":79,
+    "url":"/listings/79",
+    "title":"voluptatibus fugit saepe ipsa expedita rem",
+    "type":"Entire Place",
+    "numBeds":16,
+    "price":664,
+    "numRatings":48,
+    "avgStars":2.4,
+    "thumbnailImage":"https://picsum.photos/316/210?image=79"
+  },
+  {
+    "id":161,
+    "url":"/listings/161",
+    "title":"maiores iusto animi aut nobis",
+    "type":"Entire Place",
+    "numBeds":5,
+    "price":1452,
+    "numRatings":1718,
+    "avgStars":4.8,
+    "thumbnailImage":"https://picsum.photos/316/210?image=161"
+  },
+  {
+    "id":151,
+    "url":"/listings/151",
+    "title":"sed soluta laudantium alias et",
+    "type":"Entire Place",
+    "numBeds":9,
+    "price":158,
+    "numRatings":1194,
+    "avgStars":1.4,
+    "thumbnailImage":"https://picsum.photos/316/210?image=151"
+  },
+  {
+    "id":40,
+    "url":"/listings/40",
+    "title":"reiciendis et aliquid harum",
+    "type":"Shared Room",
+    "numBeds":4,
+    "price":1025,
+    "numRatings":332,
+    "avgStars":3.9,
+    "thumbnailImage":"https://picsum.photos/316/210?image=40"
+  },
+  {
+    "id":35,
+    "url":"/listings/35",
+    "title":"impedit exercitationem sed",
+    "type":"Entire Place",
+    "numBeds":15,
+    "price":1801,
+    "numRatings":999,
+    "avgStars":2.7,
+    "thumbnailImage":"https://picsum.photos/316/210?image=35"
+  },
+  {
+    "id":107,
+    "url":"/listings/107",
+    "title":"magni sapiente a facere asperiores",
+    "type":"Private Room",
+    "numBeds":16,
+    "price":65,
+    "numRatings":372,
+    "avgStars":4.1,
+    "thumbnailImage":"https://picsum.photos/316/210?image=107"
+  },
+  {
+    "id":164,
+    "url":"/listings/164",
+    "title":"porro ipsam quam distinctio quo quo",
+    "type":"Private Room",
+    "numBeds":15,
+    "price":414,
+    "numRatings":695,
+    "avgStars":2.4,
+    "thumbnailImage":"https://picsum.photos/316/210?image=164"
+  },
+  {
+    "id":175,
+    "url":"/listings/175",
+    "title":"consequuntur earum in accusantium",
+    "type":"Entire Place",
+    "numBeds":4,
+    "price":1429,
+    "numRatings":1399,
+    "avgStars":3.5,
+    "thumbnailImage":"https://picsum.photos/316/210?image=175"
+  },
+];

--- a/client/src/details.jsx
+++ b/client/src/details.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Details = ({type, numBeds, title, price, numRatings, avgStars}) => (
+  <div className="similar-listing-details">
+    <div className="accommodations">
+      <span className="listing-type">{type}</span>
+      <span> &#183; </span>
+      <span className="num-beds">{numBeds} Beds</span>
+    </div>
+    <div className="listing-title">
+      {title}
+    </div>
+    <div className="listing-price">
+      {price}
+    </div>
+    <div className="ratings">
+      <span className="avg-stars">{avgStars}</span>
+      <span>&nbsp;&nbsp;</span>
+      <span className="num-ratings">{numRatings}</span>
+    </div>
+  </div>
+)
+
+Details.propTypes = {
+  type: PropTypes.string.isRequired,
+  numBeds: PropTypes.number.isRequired,
+  title: PropTypes.string.isRequired,
+  price: PropTypes.number.isRequired,
+  numRatings: PropTypes.number.isRequired,
+  avgStars: PropTypes.number, // TODO: require or not require?
+};
+
+export default Details;

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import ReactDom from 'react-dom';
+import SimilarListings from './similarListings';
 
-const title = 'Minimal React Webpack Babel Setup';
+// in real life we'll want to make a GET request to the server
+// to get the listings data
+import listings from '../dummyData';
 
 ReactDom.render(
-  <div>{title}</div>,
+  <SimilarListings listings={listings} />,
   document.getElementById('app')
 );

--- a/client/src/listing.jsx
+++ b/client/src/listing.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Listing = (props) => (
+  <div>this is a listing</div>
+);
+
+Listing.propTypes = {
+  info: PropTypes.object.isRequired,
+};
+
+export default Listing;

--- a/client/src/listing.jsx
+++ b/client/src/listing.jsx
@@ -1,9 +1,38 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Listing = (props) => (
-  <div>this is a listing</div>
-);
+const Listing = ({info}) => {
+  const {
+    id,
+    url,
+    title,
+    type,
+    numBeds,
+    price,
+    numRatings,
+    avgStars,
+    thumbnailImage,
+  } = info;
+
+  const additionalDetails = {
+    title,
+    type,
+    numBeds,
+    price,
+    numRatings,
+    avgStars
+  };
+
+  return (
+  <div className="similar-listing">
+    <img src={thumbnailImage} />
+    <div className="similar-listing-details">
+      put Details component here<br />
+      {JSON.stringify(additionalDetails)}<br />
+    </div>
+  </div>
+  )
+};
 
 Listing.propTypes = {
   info: PropTypes.object.isRequired,

--- a/client/src/listing.jsx
+++ b/client/src/listing.jsx
@@ -1,41 +1,38 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Details from './details';
 
-const Listing = ({info}) => {
+const Listing = ({id, url, thumbnailImage, additionalDetails}) => {
+
   const {
-    id,
-    url,
     title,
     type,
     numBeds,
     price,
     numRatings,
     avgStars,
-    thumbnailImage,
-  } = info;
-
-  const additionalDetails = {
-    title,
-    type,
-    numBeds,
-    price,
-    numRatings,
-    avgStars
-  };
+  } = additionalDetails;
 
   return (
-  <div className="similar-listing">
-    <img src={thumbnailImage} />
-    <div className="similar-listing-details">
-      put Details component here<br />
-      {JSON.stringify(additionalDetails)}<br />
+    <div className="similar-listing">
+      <img src={thumbnailImage} />
+      <Details
+        type={type}
+        numBeds={numBeds}
+        title={title}
+        price={price}
+        numRatings={numRatings}
+        avgStars={avgStars}
+      />
     </div>
-  </div>
-  )
+  );
 };
 
 Listing.propTypes = {
-  info: PropTypes.object.isRequired,
+  id: PropTypes.number.isRequired,
+  url: PropTypes.string.isRequired,
+  thumbnailImage: PropTypes.string, // TODO: default image if none provided
+  additionalDetails: PropTypes.object.isRequired,
 };
 
 export default Listing;

--- a/client/src/similarListings.jsx
+++ b/client/src/similarListings.jsx
@@ -17,7 +17,7 @@ class SimilarListings extends React.Component {
         <h1>Similar Listings</h1>
         <div className="similar-listings-ribbon">
           {this.state.listingsShown.map(listing => (
-            <div>this represents a single listing</div>
+            <Listing key={listing.id} info={listing} />
           ))}
         </div>
       </div>

--- a/client/src/similarListings.jsx
+++ b/client/src/similarListings.jsx
@@ -1,20 +1,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Listing from './listing';
 
 class SimilarListings extends React.Component {
   constructor(props) {
     super(props);
+
+    this.state = {
+      listingsShown: props.listings.slice(0, 3), // MVP: only show 3 listings
+    };
   }
 
   render() {
     return (
-      <div testProp={this.props.testProp}>This is the Similar Listings component</div>
+      <div className="similar-listings">
+        <h1>Similar Listings</h1>
+        <div className="similar-listings-ribbon">
+          {this.state.listingsShown.map(listing => (
+            <div>this represents a single listing</div>
+          ))}
+        </div>
+      </div>
     );
   }
 }
 
 SimilarListings.propTypes = {
-  testProp: PropTypes.string.isRequired,
+  listings: PropTypes.array.isRequired,
 };
 
 export default SimilarListings;

--- a/client/src/similarListings.jsx
+++ b/client/src/similarListings.jsx
@@ -11,14 +11,34 @@ class SimilarListings extends React.Component {
     };
   }
 
+  renderListing({id, url, thumbnailImage, title, type, numBeds, price, numRatings, avgStars}) {
+    const additionalDetails = {
+      title,
+      type,
+      numBeds,
+      price,
+      numRatings,
+      avgStars,
+      thumbnailImage
+    };
+    
+    return (
+      <Listing
+        key={id}
+        id={id}
+        url={url}
+        thumbnailImage={thumbnailImage}
+        additionalDetails={additionalDetails}
+      />
+    );
+  }
+
   render() {
     return (
       <div className="similar-listings">
         <h1>Similar Listings</h1>
         <div className="similar-listings-ribbon">
-          {this.state.listingsShown.map(listing => (
-            <Listing key={listing.id} info={listing} />
-          ))}
+          {this.state.listingsShown.map(listing => this.renderListing(listing))}
         </div>
       </div>
     );

--- a/spec/__snapshots__/listing.spec.js.snap
+++ b/spec/__snapshots__/listing.spec.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Listing renders correctly 1`] = `
+<div
+  className="similar-listing"
+>
+  <img
+    src="mockImageUrl"
+  />
+  <Details
+    avgStars={0.5}
+    numBeds={2}
+    numRatings={965}
+    price={810}
+    title="nostrum laboriosam in rerum officiis"
+    type="Shared Room"
+  />
+</div>
+`;

--- a/spec/__snapshots__/similarListings.spec.js.snap
+++ b/spec/__snapshots__/similarListings.spec.js.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Similar Listings renders correctly 1`] = `
+<div
+  className="similar-listings"
+>
+  <h1>
+    Similar Listings
+  </h1>
+  <div
+    className="similar-listings-ribbon"
+  >
+    <Listing
+      additionalDetails={
+        Object {
+          "avgStars": 0.5,
+          "numBeds": 2,
+          "numRatings": 965,
+          "price": 810,
+          "thumbnailImage": "mockImageUrl",
+          "title": "nostrum laboriosam in rerum officiis",
+          "type": "Shared Room",
+        }
+      }
+      id={199}
+      key="199"
+      thumbnailImage="mockImageUrl"
+      url="mockUrl"
+    />
+    <Listing
+      additionalDetails={
+        Object {
+          "avgStars": 0.5,
+          "numBeds": 2,
+          "numRatings": 965,
+          "price": 810,
+          "thumbnailImage": "mockImageUrl",
+          "title": "nostrum laboriosam in rerum officiis",
+          "type": "Shared Room",
+        }
+      }
+      id={199}
+      key="199"
+      thumbnailImage="mockImageUrl"
+      url="mockUrl"
+    />
+    <Listing
+      additionalDetails={
+        Object {
+          "avgStars": 0.5,
+          "numBeds": 2,
+          "numRatings": 965,
+          "price": 810,
+          "thumbnailImage": "mockImageUrl",
+          "title": "nostrum laboriosam in rerum officiis",
+          "type": "Shared Room",
+        }
+      }
+      id={199}
+      key="199"
+      thumbnailImage="mockImageUrl"
+      url="mockUrl"
+    />
+  </div>
+</div>
+`;

--- a/spec/details.spec.js
+++ b/spec/details.spec.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { shallow, mount, render } from 'enzyme'; 
+import { shallowToJson } from 'enzyme-to-json';
+
+import Details from '../client/src/details';
+
+describe('Details', () => {
+  const shallowWrapper = shallow(
+    <Details
+      type="mockType"
+      numBeds={3}
+      title="mockTitle"
+      price={257}
+      numRatings={425}
+      avgStars={3.6}
+    />
+  );
+
+  test('creates a div with class "accommodations"', () => {
+    expect(shallowWrapper.find('div.accommodations').length).toBe(1);
+  });
+
+  test('creates a div with class "listing-title"', () => {
+    expect(shallowWrapper.find('div.listing-title').length).toBe(1);
+  });
+
+  test('creates a div with class "listing-price"', () => {
+    expect(shallowWrapper.find('div.listing-price').length).toBe(1);
+  });
+
+  test('creates a div with class "ratings"', () => {
+    expect(shallowWrapper.find('div.ratings').length).toBe(1);
+  });
+});

--- a/spec/listing.spec.js
+++ b/spec/listing.spec.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { shallow, mount, render } from 'enzyme'; 
+import { shallowToJson } from 'enzyme-to-json';
+
+import Listing from '../client/src/listing';
+import Details from '../client/src/details';
+
+describe('Listing', () => {
+  const id = 199;
+  const url = "mockUrl";
+  const thumbnailImage = "mockImageUrl";
+  const additionalDetails = {
+    "title":"nostrum laboriosam in rerum officiis",
+    "type":"Shared Room",
+    "numBeds":2,
+    "price":810,
+    "numRatings":965,
+    "avgStars":0.5,
+  };
+
+  const shallowWrapper = shallow(
+    <Listing
+      id={id}
+      url={url}
+      thumbnailImage={thumbnailImage}
+      additionalDetails={additionalDetails}
+    />
+  );
+
+  test('renders correctly', () => {
+    expect(shallowToJson(shallowWrapper)).toMatchSnapshot();
+  });
+
+  test('renders one <img> element', () => {
+    expect(shallowWrapper.find('img').length).toBe(1);
+  })
+
+  test('renders one Details component', () => {
+    expect(shallowWrapper.find(Details).length).toBe(1);
+  })
+})

--- a/spec/listing.spec.js
+++ b/spec/listing.spec.js
@@ -33,9 +33,9 @@ describe('Listing', () => {
 
   test('renders one <img> element', () => {
     expect(shallowWrapper.find('img').length).toBe(1);
-  })
+  });
 
   test('renders one Details component', () => {
     expect(shallowWrapper.find(Details).length).toBe(1);
-  })
-})
+  });
+});

--- a/spec/similarListings.spec.js
+++ b/spec/similarListings.spec.js
@@ -1,9 +1,30 @@
 import React from 'react';
 import { shallow, mount, render } from 'enzyme'; 
+import { shallowToJson } from 'enzyme-to-json';
 
 import SimilarListings from '../client/src/similarListings';
+import Listing from '../client/src/listing';
 
-test('renders component with props', () => {
-  const wrapper = shallow(<SimilarListings testProp="foobar" />);
-  expect(wrapper.prop('testProp')).toBe('foobar');
+describe('Similar Listings', () => {
+  const listing = {
+    "id":199,
+    "url":"mockUrl",
+    "title":"nostrum laboriosam in rerum officiis",
+    "type":"Shared Room",
+    "numBeds":2,
+    "price":810,
+    "numRatings":965,
+    "avgStars":0.5,
+    "thumbnailImage":"mockImageUrl"
+  };
+  const listings = new Array(4).fill(listing);
+  const shallowWrapper = shallow(<SimilarListings listings={listings} />);
+
+  test('renders correctly', () => {
+    expect(shallowToJson(shallowWrapper)).toMatchSnapshot();
+  })
+
+  test('renders three Listing components', () => {
+    expect(shallowWrapper.find(Listing).length).toBe(3);
+  }); 
 });


### PR DESCRIPTION
Creates the basic structure (with React and JSX) for each React component that will be used in the Similar Listings module.

**Trello Ticket:** https://trello.com/c/uFzlXXuy/48-m-create-basic-module-skeleton-using-dummy-data

### Acceptance criteria:
 - [x] Should use dummy data to render basic component structure
 - [x] Should include all elements needed for MVP version of the module (similar listings, listing, details)
 - [x] Should include 1-2 unit tests per react component, using Jest and Enzyme